### PR TITLE
refactor: use WebContents.id instead of BrowserWindow.id

### DIFF
--- a/packages/electron-bridge-ipc/electron-main/index.ts
+++ b/packages/electron-bridge-ipc/electron-main/index.ts
@@ -1,9 +1,9 @@
-import { BrowserWindow, ipcMain } from 'electron'
+import { webContents, ipcMain } from 'electron'
 import { Server } from './ipc'
 
 export function createServer() {
   ipcMain.handle('_ipc:get-context', ({ sender }) => {
-    const windowId = BrowserWindow.fromId(sender.id)?.id
+    const windowId = webContents.fromId(sender.id)?.id
     return windowId
   })
 


### PR DESCRIPTION
This ensures that the server will work with `BrowserView`, `WebContentsView` and `webview` tag as well.